### PR TITLE
FIx for missing entity 'hashtag' in EntitiesParser

### DIFF
--- a/src/NovaGram/EntitiesParser.php
+++ b/src/NovaGram/EntitiesParser.php
@@ -20,7 +20,8 @@ class EntitiesParser{
     const SKIP_ENTITES = [
         'bot_command',
         'mention',
-        'url'
+        'url',
+        'hashtag'
     ];
 
 


### PR DESCRIPTION
skrtdev\NovaGram\Exception: Could not parse Message Entities: not found entity 'hashtag', please report issue - https://novagram.ga in /websites/tools/novagram/vendor/skrtdev/novagram/src/NovaGram/EntitiesParser.php:42